### PR TITLE
Update to more modern dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,20 @@
-wheel
-pep8
-radon
-pytest-cov
-pytest
-tox
-awscli
+# -*- coding: utf-8 -*-
+# Copyright (c) CloudZero, Inc. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+autopep8==1.4.2
+awscli==1.16.96
+coverage==4.5.1
+docker==3.3.0
+flake8==3.6.0
+flake8-copyright>=0.2.0
+flake8-codeclimate>=0.2.0
+hypothesis==4.4.4
+moto==1.3.7
+pycodestyle==2.4.0
+pytest==3.5.1
+pytest-cov==2.5.1
+pytest-mock==1.10.0
+tox==3.0.0
+requests-mock==1.4.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'docopt>=0.6.2',
-        'boto3>=1.5.6',
-        'botocore>=1.8.20',
-        'simplejson>=3.13.2'
+        'boto3>=1.9.82',
+        'simplejson>=3.16.0'
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
Dev dependencies should be pinned but we can allow more modern boto/simplejson versions.  This needed to be updated because of an error I was getting with the s3transfer lib.